### PR TITLE
Make items_location facetable text

### DIFF
--- a/lib/argot/meta.rb
+++ b/lib/argot/meta.rb
@@ -1,3 +1,3 @@
 module Argot
-  VERSION = '0.3.6'.freeze
+  VERSION = '0.3.7'.freeze
 end

--- a/lib/data/solr_fields_config.yml
+++ b/lib/data/solr_fields_config.yml
@@ -322,6 +322,10 @@ biographical_sketch:
   type: t
   attr:
   - stored
+holdings:
+  type: t
+  attr:
+    -stored
 most_recent:
   type: t
   attr:
@@ -338,3 +342,7 @@ institution:
   type: f
   attr:
   - stored
+items_location:
+  type: tf
+  attr:
+    - stored


### PR DESCRIPTION
Re-establishes items_location as 'tf/stored' meaning the field updates correctly.

Update version to 0.3.7