### PR TITLE
Add url field rules; remove url_* fields rules.

### DIFF
--- a/lib/argot/flattener.rb
+++ b/lib/argot/flattener.rb
@@ -5,8 +5,6 @@ module Argot
   # Flattens an argot hash
   class Flattener
 
-    JSON_BLOB_FIELDS = %w[items].freeze
-
     def self.combine(hash1, hash2)
       hash2.each do |k, v|
         if hash1.key?(k)
@@ -40,19 +38,10 @@ module Argot
       flattened
     end
 
-    def self.create_json_blob(value)
-      if value.is_a?(Array)
-        value.map!(&:to_s)
-      else
-        value.to_s
-      end
-    end
-
     def self.process(input)
       flattened = {}
 
       input.each do |k, v|
-        v = create_json_blob(v) if JSON_BLOB_FIELDS.include?(k)
         flattened = combine(flattened, flatten(v, k)) unless v.nil?
       end
 

--- a/lib/argot/meta.rb
+++ b/lib/argot/meta.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Argot
-  VERSION = '0.4.0'
+  VERSION = '0.4.1'
 end

--- a/lib/argot/traject_writer.rb
+++ b/lib/argot/traject_writer.rb
@@ -6,7 +6,7 @@ module Argot
   # top-level attributes of the current record to scalars, which is
   # the form expected by Argot.
   class TrajectJSONWriter < Traject::JsonWriter
-    @array_fields = %w[collection holdings].to_set
+    @array_fields = %w[collection holdings url items].to_set
 
     def serialize(context)
       flatten_record!(context.output_hash)

--- a/lib/argot/traject_writer.rb
+++ b/lib/argot/traject_writer.rb
@@ -6,7 +6,7 @@ module Argot
   # top-level attributes of the current record to scalars, which is
   # the form expected by Argot.
   class TrajectJSONWriter < Traject::JsonWriter
-    @array_fields = %w[collection holdings url items].to_set
+    @array_fields = %w[holdings url items].to_set
 
     def serialize(context)
       flatten_record!(context.output_hash)

--- a/lib/data/solr_fields_config.yml
+++ b/lib/data/solr_fields_config.yml
@@ -155,14 +155,10 @@ authors_uncontrolled:
   type: t
   attr:
   - stored
-url_href:
+url:
   type: str
   attr:
-  - stored
-url_text:
-  type: t
-  attr:
-  - stored
+    -stored
 linking_main_series:
   type: t
   attr:


### PR DESCRIPTION
- Adds url to list of fields to treat as serialized data in Solr.
- Consolidates handling of serialized fields to a single place in the application. The list of serialized fields is now handled only by TrajectJSONWriter (was formerly also handled by Flattener).