### PR TITLE
Fix validator error handler invocation

### DIFF
--- a/lib/argot/cl_utilities.rb
+++ b/lib/argot/cl_utilities.rb
@@ -64,7 +64,7 @@ module Argot
     # @return 
     def validation_reporter(options)
       formatter = formatter(options)
-      lambda do |results|
+      lambda do |rec, results|
         if options.verbose
           errdoc = {
             id: rec.fetch('id', '<unknown id>'),
@@ -78,6 +78,7 @@ module Argot
         else
           warn "Document #{rec.fetch('id', '<unknown id>')} skipped (#{results.first_error})"
         end
+        false
       end
     end
 
@@ -114,7 +115,7 @@ module Argot
       validator = Argot::Validator.new
       reporter = validation_reporter(options)
       validate = lambda do |rec|
-        validator.valid?(rec) &reporter
+        validator.valid?(rec, &reporter)
       end
     end
 

--- a/lib/argot/command_line.rb
+++ b/lib/argot/command_line.rb
@@ -49,13 +49,13 @@ module Argot
 
     method_option   :quiet,
                     type: :boolean,
-                    default: true,
+                    default: false,
                     aliases: '-q',
                     desc: "Don't write records to STDOUT"
 
     method_option   :all,
                     type: :boolean,
-                    default: true,
+                    default: false,
                     aliases: '-a',
                     desc: "validate, flatten, suffix, and Solr validate results (same as full_validate)"
     

--- a/lib/argot/meta.rb
+++ b/lib/argot/meta.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Argot
-  VERSION = '0.6.5'
+  VERSION = '0.6.6'
 end

--- a/lib/argot/validator.rb
+++ b/lib/argot/validator.rb
@@ -150,18 +150,21 @@ module Argot
       end
 
       ##
-      # Tests whether a given record is valid, returning boolean +true+ if
-      # the record is valid; if a block is supplied, the block will
-      # be invoked with a collection of the errors and rules that were
-      # violated for more detailed error reporting.
+      # Tests the record for validity.
+      # if a block is supplied,  it will be called with the input record and
+      # the validation result object that indicates errors
       # @param [Hash<String, Object>] rec the Argot record to be validated.
       # @param [Fixnum] location the location in a source file currently being
       # processed.
-      # @yield [Array] the rule evaluation results that contain errors
-      def valid?(rec, location = 0)
+      # @return [Bool] true if the record is valid, false if not
+      # @yield [rec, result] an handler to be invoked if the record is not valid
+      # @yieldparam [Hash] rec the input record
+      # @yieldparam [ValidationResult] result the validation result, which
+      #  includes error messages
+      def valid?(rec, location = 0, &block)
         results = call(rec, location)
         valid = results.errors.empty?
-        yield results if block_given? && !valid
+        yield(rec, results) if block_given? && !valid
         valid
       end
 

--- a/spec/argot/validator_spec.rb
+++ b/spec/argot/validator_spec.rb
@@ -1,8 +1,45 @@
 describe Argot::Validator do
 
+  let(:invalid_rec) { { 'id' => '12345' } }
+
+  let(:minimal_valid_rec) do
+      { 'id' => '12345', 'title_main' => 'gooby', 'local_id' => {'value' => 'empty'}, 'institution' => [ 'trln']  }
+  end
+
   context '#from_files' do
     it 'sucessfully instantiates' do
 		  expect(described_class.from_files).not_to be_nil
 	   end
+  end
+
+  context '#valid?' do
+    it 'rejects an invalid document' do
+      expect(described_class.new.valid?(invalid_rec)).to be(false)
+    end
+
+    it 'passes a valid document' do
+      expect(described_class.new.valid?(minimal_valid_rec)).to be(true)
+    end
+
+    it 'passes results for invalid record to a handler block' do
+      stuff = []
+      vr = described_class.new.valid?(invalid_rec) do |r2, results|
+        stuff << [ r2, results ]
+        expect(r2).to eq(invalid_rec)
+        expect(results.errors).not_to be_empty
+      end
+      expect(vr).to be(false)
+      expect(stuff).not_to be_empty
+    end
+
+    it 'does not pass results for valid record to a handler block' do
+      stuff = []
+      vr = described_class.new.valid?(minimal_valid_rec) do |r2, results|
+        stuff << [r2, results]
+        fail "handler was called on valid record (#{results.errors.first})"
+      end
+      expect(vr).to be(true)
+      expect(stuff).to be_empty
+    end
   end
 end


### PR DESCRIPTION
Change signature of `Validator.valid?` so `block_given?` detects when we've passed a named lambda.