### PR TITLE
work_entry[:details] is now stored

### DIFF
--- a/lib/argot/flatten/flatten_work_entry.rb
+++ b/lib/argot/flatten/flatten_work_entry.rb
@@ -9,6 +9,7 @@ module Argot
     #  title: ARRAY|optional
     #  title_nonfiling: STRING|optional
     #  title_variation: STRING|optional
+    #  details: STRING|optional
     #  isbn: ARRAY|optional
     #  issn: STRING|optional
     #  other_ids: ARRAY|optional
@@ -34,6 +35,7 @@ module Argot
           display_v[:author] = v['author'] if v.has_key?('author')
           display_v[:title] = v['title'] if v.has_key?('title')
           display_v[:title_variation] = v['title_variation'] if v.has_key?('title_variation')
+          display_v[:details] = v['details'] if v.has_key?('details')
           display_v[:isbn] = v['isbn'] if v.has_key?('isbn')
           display_v[:issn] = v['issn'] if v.has_key?('issn')
 

--- a/lib/argot/meta.rb
+++ b/lib/argot/meta.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Argot
-  VERSION = '0.6.6'
+  VERSION = '0.6.7'
 end

--- a/spec/data/flattener/work_entry_expectations.yml
+++ b/spec/data/flattener/work_entry_expectations.yml
@@ -169,11 +169,13 @@ included_work:
     - author: Masson, VeNeta.
       title:
       - Rehab at the Florida Avenue Grill.
+      details: 'Washington, DC : Sage Femme Press, 1999'
       isbn:
       - '0967368804'
     - label: Contains
       title:
       - Sports illustrated.
+      details: 'Dean Smith commemorative issue (Feb. 26, 2015)'
     - title:
       - Bulletin (North Carolina Agricultural Experiment Station)
       title_variation: 1991 NC Agricultural Experiment Station Bulletin


### PR DESCRIPTION
The work_entry[:details] field was not getting added to the stored field. Now it is.