### PR TITLE
Add configurable rollup_id field.

### DIFF
--- a/lib/argot/meta.rb
+++ b/lib/argot/meta.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Argot
-  VERSION = '0.6.8'
+  VERSION = '0.6.9'
 end

--- a/lib/argot/suffixer.rb
+++ b/lib/argot/suffixer.rb
@@ -18,6 +18,8 @@ module Argot
 
     SUGGEST = 'suggest'.freeze
 
+    ROLLUP_ID = 'rollup_id'.freeze
+
     attr_reader :config, :lang_code, :vernacular
 
 
@@ -33,6 +35,7 @@ module Argot
       @vernacular = @config.fetch(:vernacular, VERNACULAR)
       @lang_code = @config.fetch(:lang_code, LANG_CODE)
       @suggest = @config.fetch(:suggest, SUGGEST)
+      @rollup_id = @config.fetch(:rollup_id, ROLLUP_ID)
       warn("config has no id atttribute: #{@config}") unless @config.key?(:id)
       warn("Config's trim attribute is not an array") unless @config.fetch(:trim, []).is_a?(Array)
       warn("Config's :ignore is not an array") unless @config.fetch(:ignore, []).is_a?(Array)
@@ -95,6 +98,8 @@ module Argot
             case orig_key
             when @config.fetch(:id, 'id')
               'id'
+            when @rollup_id
+              @rollup_id
             when /.*_#{Regexp.escape(@suggest)}/
               orig_key
             else

--- a/lib/data/solr_fields_config.yml
+++ b/lib/data/solr_fields_config.yml
@@ -367,11 +367,6 @@ reverse_shelfkey:
   attr:
   - stored
   - single
-rollup_id:
-  type: str
-  attr:
-  - stored
-  - single
 series_author:
   type: t
 series_statement_indexed:

--- a/lib/data/solr_suffixer_config.yml
+++ b/lib/data/solr_suffixer_config.yml
@@ -4,6 +4,8 @@
 
 # the key-name of the unique ID argot attribute, it will not be passed through the suffixer
 id: 'id'
+# the key-name of the unique rollup_id argot attribute. It will not be suffixed.
+rollup_id: 'rollup_id'
 # the key-name suffix used to denote language codes. Example key: title_main_vernacular_lang_code
 lang: 'lang'
 # the key-name suffix used to denote vernacular fields. Example key: title_main_vernacular

--- a/spec/argot/suffixer_spec.rb
+++ b/spec/argot/suffixer_spec.rb
@@ -5,7 +5,8 @@ describe Argot::Suffixer do
       id: 'id',
       trim: ['value'],
       vernacular: 'vernacular',
-      lang: 'lang'
+      lang: 'lang',
+      rollup_id: 'rollup_id'
     }
   end
 
@@ -32,6 +33,13 @@ describe Argot::Suffixer do
       fdoc = Argot::Flattener.new.call(doc)
       rec = described_class.new(config:config, fields: solr_fields).call(fdoc)
       expect(rec).to have_key('title_main_t')
+    end
+
+    it 'does not suffix the rollup_id field' do
+      doc = get_json('argot-allgood.json')
+      fdoc = Argot::Flattener.new.call(doc)
+      rec = described_class.new(config:config, fields: solr_fields).call(fdoc)
+      expect(rec).to have_key('rollup_id')
     end
   end
 end

--- a/spec/data/argot-allgood.json
+++ b/spec/data/argot-allgood.json
@@ -3,6 +3,7 @@
   "owner": "UNC",
   "collection" : "general",
   "local_id": "b13041770",
+  "rollup_id": "OCLC9000",
   "title":  
     {
       "sort": "Teori︠i︡a vero︠i︡atnosteĭ i ee primeneni︠i︡a",


### PR DESCRIPTION
The rollup_id field will be passed through argot-ruby unsuffixed so that it will not be handled by the dynamic field definitions in Solr. We will explicitly define a rollup_id field in Solr.