### PR TITLE
note_cited_in handled by note flattener

### DIFF
--- a/lib/argot/meta.rb
+++ b/lib/argot/meta.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Argot
-  VERSION = '0.6.16'
+  VERSION = '0.6.17'
 end

--- a/lib/data/flattener_config.yml
+++ b/lib/data/flattener_config.yml
@@ -13,6 +13,8 @@ names:
     flattener: names
 note_binding:
     flattener: note
+note_cited_in:
+    flattener: note
 note_general:
     flattener: note
 note_local:

--- a/lib/data/solr_fields_config.yml
+++ b/lib/data/solr_fields_config.yml
@@ -267,6 +267,8 @@ note_biographical:
   type: t
   attr:
   - stored
+note_cited_in_indexed:
+  type: t
 note_dissertation:
   type: t
   attr:


### PR DESCRIPTION
* Use note flattener to process note_cited_in

Draft release: https://github.com/trln/argot-ruby/releases/edit/untagged-c143bdfef44dd251ce83