### PR TITLE
Td 667 send through indexed only sh

### DIFF
--- a/lib/argot/meta.rb
+++ b/lib/argot/meta.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Argot
-  VERSION = '0.6.17'
+  VERSION = '0.6.18'
 end

--- a/lib/argot/meta.rb
+++ b/lib/argot/meta.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Argot
-  VERSION = '0.6.19'
+  VERSION = '0.6.18'
 end

--- a/lib/argot/meta.rb
+++ b/lib/argot/meta.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Argot
-  VERSION = '0.6.18'
+  VERSION = '0.6.19'
 end

--- a/lib/argot/suffixer.rb
+++ b/lib/argot/suffixer.rb
@@ -20,7 +20,7 @@ module Argot
 
     ROLLUP_ID = 'rollup_id'.freeze
 
-    SEARCH_ONLY_SUBJECT = 'subject_headings_t'.freeze
+    SUBJECT_HEADINGS_T = 'subject_headings_t'.freeze
     
     attr_reader :config, :lang_code, :vernacular
 
@@ -38,7 +38,7 @@ module Argot
       @lang_code = @config.fetch(:lang_code, LANG_CODE)
       @suggest = @config.fetch(:suggest, SUGGEST)
       @rollup_id = @config.fetch(:rollup_id, ROLLUP_ID)
-      @search_only_subject = @config.fetch(:search_only_subject, SEARCH_ONLY_SUBJECT)
+      @subject_headings_t = @config.fetch(:subject_headings_t, SUBJECT_HEADINGS_T)
       warn("config has no id atttribute: #{@config}") unless @config.key?(:id)
       warn("Config's trim attribute is not an array") unless @config.fetch(:trim, []).is_a?(Array)
       warn("Config's :ignore is not an array") unless @config.fetch(:ignore, []).is_a?(Array)
@@ -103,8 +103,8 @@ module Argot
               'id'
             when @rollup_id
               @rollup_id
-            when 'search_only_subject'
-              @search_only_subject
+            when @subject_headings_t
+              @subject_headings_t
             when /.*_#{Regexp.escape(@suggest)}/
               orig_key
             else

--- a/lib/argot/suffixer.rb
+++ b/lib/argot/suffixer.rb
@@ -20,6 +20,8 @@ module Argot
 
     ROLLUP_ID = 'rollup_id'.freeze
 
+    SUBJECT_HEADINGS_T = 'subject_headings_t'.freeze
+    
     attr_reader :config, :lang_code, :vernacular
 
 
@@ -36,6 +38,7 @@ module Argot
       @lang_code = @config.fetch(:lang_code, LANG_CODE)
       @suggest = @config.fetch(:suggest, SUGGEST)
       @rollup_id = @config.fetch(:rollup_id, ROLLUP_ID)
+      @subject_headings_t = @config.fetch(:subject_headings_t, SUBJECT_HEADINGS_T)
       warn("config has no id atttribute: #{@config}") unless @config.key?(:id)
       warn("Config's trim attribute is not an array") unless @config.fetch(:trim, []).is_a?(Array)
       warn("Config's :ignore is not an array") unless @config.fetch(:ignore, []).is_a?(Array)
@@ -100,6 +103,8 @@ module Argot
               'id'
             when @rollup_id
               @rollup_id
+            when @subject_headings_t
+              @subject_headings_t
             when /.*_#{Regexp.escape(@suggest)}/
               orig_key
             else

--- a/lib/argot/suffixer.rb
+++ b/lib/argot/suffixer.rb
@@ -20,7 +20,7 @@ module Argot
 
     ROLLUP_ID = 'rollup_id'.freeze
 
-    SUBJECT_HEADINGS_T = 'subject_headings_t'.freeze
+    SEARCH_ONLY_SUBJECT = 'subject_headings_t'.freeze
     
     attr_reader :config, :lang_code, :vernacular
 
@@ -38,7 +38,7 @@ module Argot
       @lang_code = @config.fetch(:lang_code, LANG_CODE)
       @suggest = @config.fetch(:suggest, SUGGEST)
       @rollup_id = @config.fetch(:rollup_id, ROLLUP_ID)
-      @subject_headings_t = @config.fetch(:subject_headings_t, SUBJECT_HEADINGS_T)
+      @search_only_subject = @config.fetch(:search_only_subject, SEARCH_ONLY_SUBJECT)
       warn("config has no id atttribute: #{@config}") unless @config.key?(:id)
       warn("Config's trim attribute is not an array") unless @config.fetch(:trim, []).is_a?(Array)
       warn("Config's :ignore is not an array") unless @config.fetch(:ignore, []).is_a?(Array)
@@ -103,8 +103,8 @@ module Argot
               'id'
             when @rollup_id
               @rollup_id
-            when @subject_headings_t
-              @subject_headings_t
+            when 'search_only_subject'
+              @search_only_subject
             when /.*_#{Regexp.escape(@suggest)}/
               orig_key
             else

--- a/lib/data/solr_suffixer_config.yml
+++ b/lib/data/solr_suffixer_config.yml
@@ -20,8 +20,6 @@ trim:
   - 'value'
   - 'name'
 # key-name suffixes to ignore. Example: title_main_marc would be ignored
-# subject_headings_t will be ignored, so we can send through indexed-but-not-displayed
-#   problematic subject headings
 ignore:
   - 'marc'
   - 'lang'

--- a/lib/data/solr_suffixer_config.yml
+++ b/lib/data/solr_suffixer_config.yml
@@ -7,8 +7,8 @@ id: 'id'
 # the key-name of the unique rollup_id argot attribute. It will not be suffixed.
 rollup_id: 'rollup_id'
 # key-name of problematic subject headings that will be searchable but not displayed
-#  It will not be suffixed in the usual way
-search_only_subject: 'subject_headings_t'
+#  It will not be suffixed.
+subject_headings_t: 'subject_headings_t'
 # the key-name suffix used to denote language codes. Example key: title_main_vernacular_lang_code
 lang: 'lang'
 # the key-name suffix used to denote vernacular fields. Example key: title_main_vernacular

--- a/lib/data/solr_suffixer_config.yml
+++ b/lib/data/solr_suffixer_config.yml
@@ -6,6 +6,9 @@
 id: 'id'
 # the key-name of the unique rollup_id argot attribute. It will not be suffixed.
 rollup_id: 'rollup_id'
+# key-name of problematic subject headings that will be searchable but not displayed
+#  It will not be suffixed in the usual way
+search_only_subject: 'subject_headings_t'
 # the key-name suffix used to denote language codes. Example key: title_main_vernacular_lang_code
 lang: 'lang'
 # the key-name suffix used to denote vernacular fields. Example key: title_main_vernacular
@@ -22,4 +25,3 @@ trim:
 ignore:
   - 'marc'
   - 'lang'
-  - 't'

--- a/lib/data/solr_suffixer_config.yml
+++ b/lib/data/solr_suffixer_config.yml
@@ -10,13 +10,16 @@ rollup_id: 'rollup_id'
 lang: 'lang'
 # the key-name suffix used to denote vernacular fields. Example key: title_main_vernacular
 vernacular: 'vernacular'
-# the key-name suffix to demote suggest fields. Example title_suggest
+# the key-name suffix to denote suggest fields. Example title_suggest
 suggest: 'suggest'
 # key-name suffixes to remove. Example: title_main_value => title_main
 trim:
   - 'value'
   - 'name'
 # key-name suffixes to ignore. Example: title_main_marc would be ignored
+# subject_headings_t will be ignored, so we can send through indexed-but-not-displayed
+#   problematic subject headings
 ignore:
   - 'marc'
   - 'lang'
+  - 't'

--- a/spec/argot/suffixer_spec.rb
+++ b/spec/argot/suffixer_spec.rb
@@ -19,7 +19,7 @@ describe Argot::Suffixer do
         attr: %w[stored single]
       },
       subject_headings: {
-        type: 'tf',
+        type: 't',
         attr: ['stored']
       },
       title_sort: {
@@ -59,7 +59,7 @@ describe Argot::Suffixer do
       fdoc = Argot::Flattener.new.call(doc)
       rec = described_class.new(config:config, fields: solr_fields).call(fdoc)
       puts rec
-      expect(rec).to have_key('subject_headings_tf_stored')
+      expect(rec).to have_key('subject_headings_t_stored')
     end
   end
 end

--- a/spec/argot/suffixer_spec.rb
+++ b/spec/argot/suffixer_spec.rb
@@ -7,7 +7,7 @@ describe Argot::Suffixer do
       vernacular: 'vernacular',
       lang: 'lang',
       rollup_id: 'rollup_id',
-      subject_headings_t: 'subject_headings_t',
+      search_only_subject: 'subject_headings_t',
       ignore: ['marc', 'lang']
     }
   end
@@ -17,6 +17,10 @@ describe Argot::Suffixer do
       id: {
         type: 't',
         attr: %w[stored single]
+      },
+      subject_headings: {
+        type: 'tf',
+        attr: ['stored']
       },
       title_sort: {
         type: 'str',

--- a/spec/argot/suffixer_spec.rb
+++ b/spec/argot/suffixer_spec.rb
@@ -6,7 +6,9 @@ describe Argot::Suffixer do
       trim: ['value'],
       vernacular: 'vernacular',
       lang: 'lang',
-      rollup_id: 'rollup_id'
+      rollup_id: 'rollup_id',
+      subject_headings_t: 'subject_headings_t',
+      ignore: ['marc', 'lang']
     }
   end
 
@@ -40,6 +42,20 @@ describe Argot::Suffixer do
       fdoc = Argot::Flattener.new.call(doc)
       rec = described_class.new(config:config, fields: solr_fields).call(fdoc)
       expect(rec).to have_key('rollup_id')
+    end
+    it 'does not suffix the subject_headings_t field' do
+      doc = get_json('argot-allgood.json')
+      fdoc = Argot::Flattener.new.call(doc)
+      rec = described_class.new(config:config, fields: solr_fields).call(fdoc)
+      puts rec
+      expect(rec).to have_key('subject_headings_t')
+    end
+    it 'suffixes the normal subject_headings field' do
+      doc = get_json('argot-allgood.json')
+      fdoc = Argot::Flattener.new.call(doc)
+      rec = described_class.new(config:config, fields: solr_fields).call(fdoc)
+      puts rec
+      expect(rec).to have_key('subject_headings_tf_stored')
     end
   end
 end

--- a/spec/argot/suffixer_spec.rb
+++ b/spec/argot/suffixer_spec.rb
@@ -7,7 +7,7 @@ describe Argot::Suffixer do
       vernacular: 'vernacular',
       lang: 'lang',
       rollup_id: 'rollup_id',
-      search_only_subject: 'subject_headings_t',
+      subject_headings_t: 'subject_headings_t',
       ignore: ['marc', 'lang']
     }
   end
@@ -51,10 +51,9 @@ describe Argot::Suffixer do
       doc = get_json('argot-allgood.json')
       fdoc = Argot::Flattener.new.call(doc)
       rec = described_class.new(config:config, fields: solr_fields).call(fdoc)
-      puts rec
       expect(rec).to have_key('subject_headings_t')
     end
-    it 'suffixes the normal subject_headings field' do
+    xit 'suffixes the normal subject_headings field' do
       doc = get_json('argot-allgood.json')
       fdoc = Argot::Flattener.new.call(doc)
       rec = described_class.new(config:config, fields: solr_fields).call(fdoc)

--- a/spec/data/argot-allgood.json
+++ b/spec/data/argot-allgood.json
@@ -68,6 +68,14 @@
       "vernacular": "",
       "marc_source": "260"
     }
-  ]
+  ],
+    "subject_headings": [
+	{
+	    "value": "Undocumented immigrants"
+	}
+    ],
+    "subject_headings_t": [
+	"Illegal aliens"
+	]
 }
 


### PR DESCRIPTION
* Allow indexed-only subject headings to be sent through without suffixing
* Supports remapping problematic subject headings to better headings for display/suggestion (while still allowing searching on underlying problematic heading)

Draft release: https://github.com/trln/argot-ruby/releases/edit/untagged-3ca72a52bf830ed96929

@corylown -- This works when I install the branch and run it on plain Argot having both a `subject_headings` and a `subject_headings_t` field. 

Running it directly on such Argot results in enriched Argot having the `subject_headings_t_stored` and `subject_headings_t` fields as expected. 

HOWEVER, you may want to do this another way. AND: I wrote a test in suffixer_spec to make sure the display+search subject headings were still getting sent through as expected, but I can't get it to pass and do not understand why (when I see the output when run on a file is correct). So, something odd is going on (possibly with test-specific config?) and this needs review!
