### PR TITLE
store publisher field

### DIFF
--- a/lib/argot/meta.rb
+++ b/lib/argot/meta.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Argot
-  VERSION = '0.7.0'
+  VERSION = '0.7.1'
 end

--- a/lib/data/solr_fields_config.yml
+++ b/lib/data/solr_fields_config.yml
@@ -343,6 +343,8 @@ publication_year:
   - sort
 publisher:
   type: t
+  attr:
+  - stored
 publisher_number:
   type: str
   attr:


### PR DESCRIPTION
Draft release: https://github.com/trln/argot-ruby/releases/edit/untagged-75bf822911749db476c3

Stores the previous index-only `publisher` field. 

Supports integration with Zotero and other citation building/extracting tools, and population of request forms.