### PR TITLE
configure 3 new fields

### DIFF
--- a/lib/argot/meta.rb
+++ b/lib/argot/meta.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Argot
-  VERSION = '0.7.1'
+  VERSION = '0.7.2'
 end

--- a/lib/data/flattener_config.yml
+++ b/lib/data/flattener_config.yml
@@ -25,6 +25,8 @@ note_related_work:
     flattener: note
 note_reproduction:
     flattener: note
+origin_place_search:
+    flattener: indexed_value
 series_statement:
     flattener: series_statement
 title_main:

--- a/lib/data/flattener_config.yml
+++ b/lib/data/flattener_config.yml
@@ -25,8 +25,6 @@ note_related_work:
     flattener: note
 note_reproduction:
     flattener: note
-origin_place_search:
-    flattener: indexed_value
 series_statement:
     flattener: series_statement
 title_main:

--- a/lib/data/solr_fields_config.yml
+++ b/lib/data/solr_fields_config.yml
@@ -95,6 +95,10 @@ genre_headings:
   type: t
   attr:
   - stored
+genre_unc_mrc:
+  type: tf
+  attr:
+  - stored
 has_supplement_author:
   type: t
 has_supplement_title:

--- a/lib/data/solr_fields_config.yml
+++ b/lib/data/solr_fields_config.yml
@@ -332,6 +332,14 @@ organization:
   type: t
   attr:
   - stored
+origin_place_facet:
+  type: f
+  attr:
+  - stored
+origin_place_search:
+  type: t
+  attr:
+  - stored
 physical_description_indexed:
   type: t
 physical_description_details_indexed:


### PR DESCRIPTION
Draft release: https://github.com/trln/argot-ruby/releases/edit/untagged-fce44a2cce6778e8d206

MTA pr that includes these fields: https://github.com/trln/marc-to-argot/pull/207

* Adds `genre_unc_mrc` to solr_fields_config as a stored tf field. 
** This field will be used to populate a "Genre" limit dropdown box on a special scoped search interface for our Media Resources Center, which uses their own genre vocabulary and only wants their genre terms to show up in their dropdown limit. 
* Adds `origin_place_facet` and `origin_place_search` to solr_fields_config
* `origin_place_search` flattened with `indexed_value` flattener