### PR TITLE
Add note fields derived from EAD data

### DIFF
--- a/lib/argot/meta.rb
+++ b/lib/argot/meta.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Argot
-  VERSION = '1.0.1'
+  VERSION = '1.0.2'
 end

--- a/lib/data/flattener_config.yml
+++ b/lib/data/flattener_config.yml
@@ -15,6 +15,14 @@ note_binding:
     flattener: note
 note_cited_in:
     flattener: note
+note_ead_biog_hist:
+    flattener: note
+note_ead_overview:
+    flattener: note
+note_ead_scope_content:
+    flattener: note
+note_ead_unit_title:
+    flattener: note
 note_general:
     flattener: note
 note_local:

--- a/lib/data/solr_fields_config.yml
+++ b/lib/data/solr_fields_config.yml
@@ -281,6 +281,14 @@ note_dissertation:
   type: t
   attr:
   - stored
+note_ead_biog_hist_indexed:
+  type: t
+note_ead_overview_indexed:
+  type: t
+note_ead_scope_content_indexed:
+  type: t
+note_ead_unit_title_indexed:
+  type: t
 note_general_indexed:
   type: t
 note_issuance:


### PR DESCRIPTION
* Adds four EAD-derived argot fields that can be index-only via the `notes` flattener:
`note_ead_biog_hist`, `note_ead_overview`, `note_ead_scope_content`, `note_ead_unit_title`
* Adds `#{field}_indexed` t solr fields for each of the EAD fields