### PR TITLE
use thor 1.0 and up

### DIFF
--- a/argot.gemspec
+++ b/argot.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
     s.add_runtime_dependency 'nokogiri', '~> 1.10'
 
     s.add_runtime_dependency 'traject', [ '~> 2.0' ]
-    s.add_runtime_dependency 'thor', ['~> 0.20.0']
+    s.add_runtime_dependency 'thor', ['~> 1.0']
     s.add_runtime_dependency 'rsolr', [ '~> 1.1', '>=1.1.2']
 
     # system rubies may be installed wihtout minitest

--- a/lib/argot/meta.rb
+++ b/lib/argot/meta.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Argot
-  VERSION = '1.0.6'
+  VERSION = '1.0.7'
 end


### PR DESCRIPTION
Updates the `thor` dependency (provides command-line features) to 1.0 and up, for compatibility with Rails 6.1

No functional changes.